### PR TITLE
add GitHub Flavored Markdown to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,45 +11,59 @@ A jruby memcached gem which is compatible with evan's [memcached][0] gem
 Now, in Ruby, require the library and instantiate a Memcached object at
 a global level:
 
-    require 'memcached'
-    $cache = Memcached.new("localhost:11211")
+```ruby
+require 'memcached'
+$cache = Memcached.new("localhost:11211")
+```
 
 Now you can set things and get things:
 
-    value = 'hello'
-    $cache.set 'test', value
-    $cache.get 'test' #=> "hello"
+```ruby
+value = 'hello'
+$cache.set 'test', value
+$cache.get 'test' #=> "hello"
+```
 
 You can set with an expiration timeout:
 
-    value = 'hello'
-    $cache.set 'test', value, 1
-    sleep(2)
-    $cache.get 'test' #=> raises Memcached::NotFound
+```ruby
+value = 'hello'
+$cache.set 'test', value, 1
+sleep(2)
+$cache.get 'test' #=> raises Memcached::NotFound
+```
 
 You can get multiple values at once:
 
-    value = 'hello'
-    $cache.set 'test', value
-    $cache.set 'test2', value
-    $cache.get ['test', 'test2', 'missing']
-      #=> {"test" => "hello", "test2" => "hello"}
+```ruby
+value = 'hello'
+$cache.set 'test', value
+$cache.set 'test2', value
+$cache.get ['test', 'test2', 'missing']
+  #=> {"test" => "hello", "test2" => "hello"}
+```
 
 You can set a counter and increment it. Note that you must initialize it
 with an integer, encoded as an unmarshalled ASCII string:
 
-    $cache.increment 'counter' #=> 1
-    $cache.increment 'counter' #=> 2
-    $cache.get('counter').to_i #=> 2
+```ruby
+$cache.increment 'counter' #=> 1
+$cache.increment 'counter' #=> 2
+$cache.get('counter').to_i #=> 2
+```
 
 You can get some server stats:
 
-    $cache.stats #=> {..., :bytes_written=>[62], :version=>["1.2.4"] ...}
+```ruby
+$cache.stats #=> {..., :bytes_written=>[62], :version=>["1.2.4"] ...}
+```
 
 ## Rails
 
-  # config/environment.rb
-  config.cache_store = Memcached::Rails.new(:servers => ['127.0.0.1'])
+```ruby
+# config/environment.rb
+config.cache_store = Memcached::Rails.new(:servers => ['127.0.0.1'])
+```
 
 ## Benchmarks
 


### PR DESCRIPTION
- This makes the example code easier to read, especially when perusing the docs on github
